### PR TITLE
Added home and about text

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -25,3 +25,7 @@ body {
     color: blue;
     text-align: center;
 }
+
+li {
+    margin: 1em 0;
+}

--- a/webcalc/templates/about.html
+++ b/webcalc/templates/about.html
@@ -10,7 +10,7 @@
         <h3>Data format</h3>
 
         <p>
-            The simplest way to understand the format of the input data is to look at examples on the <a href="{% url 'about' %}">Datasets</a> page. Read below for more details:
+            The simplest way to understand the format of the input data is to look at examples on the <a href="{% url 'media' %}">Datasets</a> page. Read below for more details:
         </p>
         <ol>
             <li>
@@ -76,18 +76,18 @@
 
                 {% latexify 'P(x|y) = \frac{C(yx)}{C(y)}' math_block=True %}
 
-                where {% latexify 'C(y)' math_inline=True %} is the number of times the symbol {% latexify 'x' math_inline=True %} occurs in the training data and {% latexify 'C(yx)' math_inline=True %} is the number of times the sequence {% latexify 'yx' math_inline=True %} occurs in the training data. For bigram probabilities these counts are <i>Laplace Smoothed</i>: each possible bigram sequence begins with a count of 1, rather than 0. This means that bigram sequences not observed in the training data (that is, where {% latexify 'C(yx) = 0' math_inline=True %}) are treated as though they have been observed once, which gives them a small, rather than zero, probability.
+                where {% latexify 'C(y)' math_inline=True %} is the number of times the symbol {% latexify 'y' math_inline=True %} occurs in the training data and {% latexify 'C(yx)' math_inline=True %} is the number of times the sequence {% latexify 'yx' math_inline=True %} occurs in the training data. For bigram probabilities these counts are <i>Laplace Smoothed</i>: each possible bigram sequence begins with a count of 1, rather than 0. This means that bigram sequences not observed in the training data (that is, where {% latexify 'C(yx) = 0' math_inline=True %}) are treated as though they have been observed once, which gives them a small, rather than zero, probability.
 
                 <p>
                     Each word is padded with a special start and end symbol, which allows us to calculate bigram probabilities for symbols that begin and end words.
                 </p>
                 <p>
-                    This metric reflects the probability of words under a simple bigram model. The probability of a word is the product of the probability of all the bigrams in contains. Note that the probability of the bigrams is based only on their frequency of occurrence, not the position in which they occur or their sequencing with respect to one another.
+                    This metric reflects the probability of words under a simple bigram model. The probability of a word is the product of the probability of all the bigrams it contains. Note that the probability of the bigrams is based only on their frequency of occurrence, not the position in which they occur or their sequencing with respect to one another.
                 </p>
             </li>
             <li>
                 <p>
-                    <b>Positional unigram score</b> (<tt>pos_uni_prob</tt>): This is a type-weighted variant of unigram score from Vitevich and Luce (2004). 
+                    <b>Positional unigram score</b> (<tt>pos_uni_prob</tt>): This is a type-weighted variant of unigram score from Vitevitch and Luce (2004). 
 
                     {% latexify 'PosUniScore(w=x_1 \dots x_n) \approx 1 + \sum_{i=1}^{n} P(w_i = x_i)' math_block=True %}
 
@@ -98,12 +98,15 @@
                     where {% latexify 'w_i' math_inline=True %} refers to the {% latexify 'i^{\text{th}}' math_inline=True %} position in a word and {% latexify 'C(w_i = x)' math_inline=True %} is the number of times in the training data the symbol {% latexify 'x' math_inline=True %} occurs in the {% latexify 'i^{\text{th}}' math_inline=True %} position of a word.
                 </p>
                 <p>
-                    Under this metric, the score assigned to a word is based on the sum of the probability of its individual symbols occuring at their respective positions. Note that the ordering of the symbols with respect to one another does not affect the score, only their relative frequencies within their given positions. Higher scores represent words with more probable phonotactics, but note that this scores cannot be interpreted as probabilities.
+                    Vitevitch and Luce (2004) add 1 to the sum of the unigram probabilities " to aid in locating these values when you cut and paste the output in the right field to another program." They recommend subtracting 1 from these values before reporting them.
+                </p>
+                <p>
+                    Under this metric, the score assigned to a word is based on the sum of the probability of its individual symb1ols occuring at their respective positions. Note that the ordering of the symbols with respect to one another does not affect the score, only their relative frequencies within their given positions. Higher scores represent words with more probable phonotactics, but note that this score cannot be interpreted as a probability.
                 </p>
             </li>
             <li>
                 <p>
-                    <b>Positional bigram score</b> (<tt>pos_bi_prob</tt>): This is a type-weighted variant of the bigram score from Vitevich and Luce (2004). 
+                    <b>Positional bigram score</b> (<tt>pos_bi_prob</tt>): This is a type-weighted variant of the bigram score from Vitevitch and Luce (2004). 
 
                     {% latexify 'PosBiScore(w=x_1 \dots x_n) \approx 1 + \sum_{i=2}^{n} P(w_{i-1} = x_{i-1}, w_i = x_i)' math_block=True %}
 
@@ -114,7 +117,10 @@
                     where {% latexify 'w_i' math_inline=True %} refers to the {% latexify 'i^{\text{th}}' math_inline=True %} position in a word and {% latexify 'C(w_{i-1} = y, w_i = x)' math_inline=True %} is the number of times in the training data the sequence {% latexify 'yx' math_inline=True %} occurs at the {% latexify '(i-1)^{\text{th}}' math_inline=True %} and {% latexify 'i^{\text{th}}' math_inline=True %} positions of a word.
                 </p>
                 <p>
-                    Under this metric, the score assigned to a word is based on the sum of the probability of each contiguous pair of symbols occuring at their respective positions. Higher scores represent words with more probable phonotactics, but note that this scores cannot be interpreted as probabilities.
+                    Vitevitch and Luce (2004) add 1 to the sum of the bigram probabilities " to aid in locating these values when you cut and paste the output in the right field to another program." They recommend subtracting 1 from these values before reporting them.
+                </p>
+                <p>
+                    Under this metric, the score assigned to a word is based on the sum of the probability of each contiguous pair of symbols occuring at their respective positions. Higher scores represent words with more probable phonotactics, but note that this score cannot be interpreted as a probability.
                 </p>
             </li>
             <li>
@@ -131,7 +137,7 @@
                     For example, suppose we have a corpus containing two word types "kæt", which occurs 1000 times, and "tæk", which occurs 50 times. Under a token-weighted unigram model, {% latexify 'C(æ) = ln(1000) + ln(50) \approx 10.82' math_inline=True %}, while in a type-weighted unigram model {% latexify 'C(æ) = 1 + 1 = 2' math_inline=True %}. 
                 </p>
                 <p>
-                    The token-weighted positional ungiram and bigram scores correspond to the metrics presented in Vitevich and Luce (2004; though they use the base-10 logarithm rather than the natural logarithm).
+                    The token-weighted positional ungiram and bigram scores correspond to the metrics presented in Vitevitch and Luce (2004), though they use the base-10 logarithm rather than the natural logarithm.
                 </p>
                 <p>
                     The token-weighted bigram measures are also Laplace smoothed.
@@ -148,6 +154,15 @@
         <p>
             This model is run separately from the unigram/bigram models above because it is more time-consuming to train. The model is run with the default settings described in the paper. Readers who are interested in changing the parameters of this model are encouraged to use the command-line interface available on the project's <a href="https://github.com/MaxAndrewNelson/Phonotactic_LM">Github repository</a>.
         </p>
+        <hr>
+        <h4>References</h4>
+        <p>
+            Mayer, C., &amp; Nelson, M. (2020). Phonotactic learning with neural language models. <i>Proceedings of the Society for Computation in Linguistics.</i> Vol. 3. Article 16.
+        </p>
+        <p>
+            Vitevitch, M.S., &amp Luce, P.A. (2004). A web-based interface to calculate phonotactic probability for words and nonwords in English. <i>Behavior Research Methods, Instruments, &amp; Computers, 36</i>(3), 481-487.      
+        </p>
+
         <!-- <object data = "media/descriptions/about.txt" width = "100%" height = "100%"></object> -->
     </div>
 {% endblock content %}

--- a/webcalc/templates/about.html
+++ b/webcalc/templates/about.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <div style="padding:40px;margin:40px;border:1px solid #ccc">
-        <center><h1>About the Phonotactic Calculator</h1></center>
-        <object data = "/media/descriptions/about.txt" width = "100%" height = "100%"></object>
+        <center><h3>About the UCI Phonotactic Calculator</h3></center>
+        <!-- <object data = "media/descriptions/about.txt" width = "100%" height = "100%"></object> -->
     </div>
 {% endblock content %}

--- a/webcalc/templates/about.html
+++ b/webcalc/templates/about.html
@@ -1,9 +1,153 @@
 <!-- templates/about.html -->
 {% extends 'base.html' %}
+{% load latexify %}
 
 {% block content %}
     <div style="padding:40px;margin:40px;border:1px solid #ccc">
-        <center><h3>About the UCI Phonotactic Calculator</h3></center>
+        <h2>About the UCI Phonotactic Calculator</h2>
+
+        <hr>
+        <h3>Data format</h3>
+
+        <p>
+            The simplest way to understand the format of the input data is to look at examples on the <a href="{% url 'about' %}">Datasets</a> page. Read below for more details:
+        </p>
+        <ol>
+            <li>
+                Both the training and the test file must in comma-separated format (.csv). 
+            </li>
+            <li>
+                The training file should consist of two columns with no headers. 
+                <ol>
+                    <li>
+                        The first column contains a word list, with each symbol (phoneme, orthographic letter, etc.) separated by spaces. For example, the word 'cat' represented in IPA would be "k æ t". You may use any transcription system or representation you like, so long as the individual symbols are separated by spaces. Because symbols are space-separated, they may be arbitrarily long: this allows the use of transcription systems like ARPABET, which use more than one character to represent individual sounds.
+                    </li>
+                    <li>
+                        The second column contains the corresponding word frequencies for each word. These must be expressed as raw counts. These values are used in the token-weighted variants of the unigram and bigram models, which ascribe greater influence to the phonotactics of more frequent words. If this column is not provided, the token-weighted metrics will not be computed, but the other metrics will be returned. 
+                    </li>
+                </ol>
+            </li>
+            <li>
+                The test file should consist of a single column containing the test word list. The same format as the training file must be used.
+            </li>
+            <li>
+                The output file will contain one column containing the test words, one column containing the number of symbols in the word, and one column for each of the metrics.
+            </li>
+        </ol>
+
+        <hr>
+        <h3>The metrics</h3>
+
+        <p>
+            The UCI Phonotactic Calculator currently supports two broad classes of models. We refrain here from any discussion of the appropriateness of each model, and discuss only how each score is computed.
+        </p>
+        <p>
+            In the equations below, {% latexify '\Sigma' math_inline=True %} represents the set of symbols that comprise the training data (the set of phonemes, characters, etc.) and {% latexify 'w = x_1 \dots x_n' math_inline=True %} refers to a word {% latexify 'w' math_inline=True %} that consists of symbols {% latexify 'x_1' math_inline=True %} through {% latexify 'x_n' math_inline=True %}.
+        </p>
+
+        <h4>Unigram/bigram scores</h4>
+
+        <p>
+            This is a suite of metrics that share the property of being sensitive only to the frequencies of individual sounds or adjacent pairs of sounds.
+        </p>
+
+        <ul>
+            <li>
+                <b>Unigram probability</b> (<tt>uni_prob</tt>): This is the standard unigram probability 
+
+                {% latexify 'P(w=x_1 \dots x_n) \approx \prod_{i=1}^{n} P(x_i)' math_block=True %}
+
+                where
+
+                {% latexify 'P(x) = \frac{C(x)}{\displaystyle\sum_{y \in \Sigma} C(y)}' math_block=True %}
+
+                where {% latexify 'C(x)' math_inline=True %} is the number of times the symbol {% latexify 'x' math_inline=True %} occurs in the training data.
+
+                <p>
+                    This metric reflects the probability of a word under a simple unigram model. The probability of a word is the product of the probability of its individual symbols. Note that the probability of the individual symbols is based only on their frequency of occurrence, not the position in which they occur.
+                </p>
+            </li>
+            <li>
+                <b>Bigram probability</b> (<tt>bi_prob</tt>): This is the standard bigram probability 
+
+                {% latexify 'P(w=x_1 \dots x_n) \approx \prod_{i=2}^{n} P(x_i|x_{i-1})' math_block=True %}
+
+                where
+
+                {% latexify 'P(x|y) = \frac{C(yx)}{C(y)}' math_block=True %}
+
+                where {% latexify 'C(y)' math_inline=True %} is the number of times the symbol {% latexify 'x' math_inline=True %} occurs in the training data and {% latexify 'C(yx)' math_inline=True %} is the number of times the sequence {% latexify 'yx' math_inline=True %} occurs in the training data. For bigram probabilities these counts are <i>Laplace Smoothed</i>: each possible bigram sequence begins with a count of 1, rather than 0. This means that bigram sequences not observed in the training data (that is, where {% latexify 'C(yx) = 0' math_inline=True %}) are treated as though they have been observed once, which gives them a small, rather than zero, probability.
+
+                <p>
+                    Each word is padded with a special start and end symbol, which allows us to calculate bigram probabilities for symbols that begin and end words.
+                </p>
+                <p>
+                    This metric reflects the probability of words under a simple bigram model. The probability of a word is the product of the probability of all the bigrams in contains. Note that the probability of the bigrams is based only on their frequency of occurrence, not the position in which they occur or their sequencing with respect to one another.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <b>Positional unigram score</b> (<tt>pos_uni_prob</tt>): This is a type-weighted variant of unigram score from Vitevich and Luce (2004). 
+
+                    {% latexify 'PosUniScore(w=x_1 \dots x_n) \approx 1 + \sum_{i=1}^{n} P(w_i = x_i)' math_block=True %}
+
+                    where
+
+                    {% latexify 'P(w_i = x) = \frac{C(w_i = x)}{\displaystyle\sum_{y \in \Sigma} C(w_i = y)}' math_block=True %}
+
+                    where {% latexify 'w_i' math_inline=True %} refers to the {% latexify 'i^{\text{th}}' math_inline=True %} position in a word and {% latexify 'C(w_i = x)' math_inline=True %} is the number of times in the training data the symbol {% latexify 'x' math_inline=True %} occurs in the {% latexify 'i^{\text{th}}' math_inline=True %} position of a word.
+                </p>
+                <p>
+                    Under this metric, the score assigned to a word is based on the sum of the probability of its individual symbols occuring at their respective positions. Note that the ordering of the symbols with respect to one another does not affect the score, only their relative frequencies within their given positions. Higher scores represent words with more probable phonotactics, but note that this scores cannot be interpreted as probabilities.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <b>Positional bigram score</b> (<tt>pos_bi_prob</tt>): This is a type-weighted variant of the bigram score from Vitevich and Luce (2004). 
+
+                    {% latexify 'PosBiScore(w=x_1 \dots x_n) \approx 1 + \sum_{i=2}^{n} P(w_{i-1} = x_{i-1}, w_i = x_i)' math_block=True %}
+
+                    where
+
+                    {% latexify 'P(w_{i-1} = y, w_i = x) = \frac{C(w_{i-1} = y, w_i = x)}{\displaystyle\sum_{z \in \Sigma}\sum_{v \in \Sigma} C(w_{i-1} = z, w_i = v)}' math_block=True %}
+
+                    where {% latexify 'w_i' math_inline=True %} refers to the {% latexify 'i^{\text{th}}' math_inline=True %} position in a word and {% latexify 'C(w_{i-1} = y, w_i = x)' math_inline=True %} is the number of times in the training data the sequence {% latexify 'yx' math_inline=True %} occurs at the {% latexify '(i-1)^{\text{th}}' math_inline=True %} and {% latexify 'i^{\text{th}}' math_inline=True %} positions of a word.
+                </p>
+                <p>
+                    Under this metric, the score assigned to a word is based on the sum of the probability of each contiguous pair of symbols occuring at their respective positions. Higher scores represent words with more probable phonotactics, but note that this scores cannot be interpreted as probabilities.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <b>Token-weighted variants</b>: Assuming that the training data consists of a list of word types (e.g., a dictionary), the above metrics can be described as <i>type-weighted</i>: the frequency of individual word types has no bearing on the scores assigned by the metrics.
+                </p>
+                <p>
+                    The calculator also includes <i>token-weighted</i> variants of each of the above measures, where the phonotactic properties of frequent word types are weighted higher than those in less frequent word types. These are included under the column names <tt>uni_tok_prob, bi_tok_prob, pos_uni_tok, pos_bi_tok</tt>.
+                </p>
+                <p>
+                    These measures are computed by changing the count function {% latexify 'C' math_inline=True %} such that it is the number of occurrences of the configuration in question multiplied by the natural log of the count of the word containing each occurrence.
+                </p>
+                <p>
+                    For example, suppose we have a corpus containing two word types "kæt", which occurs 1000 times, and "tæk", which occurs 50 times. Under a token-weighted unigram model, {% latexify 'C(æ) = ln(1000) + ln(50) \approx 10.82' math_inline=True %}, while in a type-weighted unigram model {% latexify 'C(æ) = 1 + 1 = 2' math_inline=True %}. 
+                </p>
+                <p>
+                    The token-weighted positional ungiram and bigram scores correspond to the metrics presented in Vitevich and Luce (2004; though they use the base-10 logarithm rather than the natural logarithm).
+                </p>
+                <p>
+                    The token-weighted bigram measures are also Laplace smoothed.
+                </p>
+            </li>
+        </ul> 
+        <h4>RNN Model</h4>
+        <p>
+            The RNN model implements the simple recurrent neural network model of phonotactics presented in <a href="https://www.socsci.uci.edu/~cjmayer/papers/cmayer_mnelson_neural_phonotactics_2019.pdf">Mayer and Nelson (2020)</a>. The primary difference between this model and the unigram/bigram models above is that it is not restricted to a fixed context window: while the unigram/bigram measures are restricted to considering individual sounds or contiguous pairs of sounds, the RNN model can (in principle) learn phonotactic constraints that span arbitrarily long distances. We refer the reader to the original paper for details of how these scores are computed.
+        </p>
+        <p>
+            The scores computed by this model are <i>perplexities</i> rather than probabilities. Lower perplexities correspond to higher probabilities.
+        </p>
+        <p>
+            This model is run separately from the unigram/bigram models above because it is more time-consuming to train. The model is run with the default settings described in the paper. Readers who are interested in changing the parameters of this model are encouraged to use the command-line interface available on the project's <a href="https://github.com/MaxAndrewNelson/Phonotactic_LM">Github repository</a>.
+        </p>
         <!-- <object data = "media/descriptions/about.txt" width = "100%" height = "100%"></object> -->
     </div>
 {% endblock content %}

--- a/webcalc/templates/base.html
+++ b/webcalc/templates/base.html
@@ -1,11 +1,12 @@
 <!-- templates/base.html -->
 
 {% load static %}
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>UCI Phonotactic Calculator</title>
         <link href="{% static 'css/base.css' %}" rel="stylesheet">
+        {% include 'latexify/stylesheets.html' %}
     </head>
 
     <body>
@@ -35,5 +36,6 @@
     
         {% block content %}
         {% endblock content %}
+        {% include "latexify/scripts.html" %}
     </body>
 </html>

--- a/webcalc/templates/base.html
+++ b/webcalc/templates/base.html
@@ -4,7 +4,7 @@
 
 <html>
     <head>
-        <title>Phonotactic Web Calculator</title>
+        <title>UCI Phonotactic Calculator</title>
         <link href="{% static 'css/base.css' %}" rel="stylesheet">
     </head>
 
@@ -29,7 +29,7 @@
         </div>
         <div class="page-title">
             <h1>
-                Phonotactic Web Calculator
+                UCI Phonotactic Calculator
             </h1>
         </div>
     

--- a/webcalc/templates/home.html
+++ b/webcalc/templates/home.html
@@ -3,11 +3,37 @@
 
 {% block content %}
     <div style="padding:40px;margin:40px;border:1px solid #ccc">
-        <object data = "/media/descriptions/home.txt" width = "100%" height = "250"></object>
+        <center><h3> Welcome to the UCI Phonotactic Calculator! </h3></center>
+
+        <p>This is a research tool that allows users to calculate a variety of <i>phonotactic acceptability metrics</i>. These metrics are intended to capture how probable/acceptable a word is based on the sounds it contains and the order in which those sounds are sequenced. This is sometimes referred to as <i>phonotactic probability</i>, though we prefer the term <i>acceptability</i> because not all of the metrics employed here can be interpreted as probabilities. For example, a nonce word like [stik] 'steek' might have a relatively high phonotactic acceptability score in English even though it is not a real word, because there are many words that begin with [st], end with [ik], and so on. In Spanish, however, this word would have a low acceptability score because there are no Spanish words that begin with the sequence [st]. A sensitivity to the phonotactic constraints of one's language(s) is an important component of linguistic competence, and the various metrics computed by this tool instantiate different models of how this sensitivity is operationalized.</p>
+
+        <p>The general use case for this tool is as follows:</p>
+        <ol>
+            <li>
+                Choose a <i>training file</i>. You can either upload your own or choose one of the default training files (see the <a href="{% url 'about' %}">About</a> page for details on how these should be formatted and the <a href="{% url 'about' %}">Datasets</a> page for a description of the default files). This file is intended to represent the input over which phonotactic generalizations are formed, and will typically be something like a dictionary (a large list of word types). The models used to calculate the phonotactic acceptability metrics will be fit to this data.
+            </li>
+            <li>
+                Upload a <i>test file</i>. The trained models will assign scores for each metric to the words in this file. This file may duplicate data in the training file (if you are interested in the scores assigned to existing words) or not (if you are interested in the predictions the various models make about how speakers generalize to new forms).
+            </li>
+            <li>
+                Choose which <i>model</i> to use. Currently the calculator supports two suites of models.
+                <ol>
+                    <li>
+                        <b>Unigram/Bigram scores</b>: this computes a suite of metrics that are based on unigram/bigram frequencies (that is, the frequencies of individual sounds and the frequencies of adjacent pairs of sounds). This includes type- and token-weighted variants of the positional unigram/bigram method from Jusczyk et al. (1994) and Vitevich and Luce (2004), as well as type- and token-weighted variants of standard unigram/bigram probabilities.
+                    </li>
+                    <li>
+                        <b>RNN Model</b>: this computes an acceptability metric based on the recurrent neural network phonotactic model from Mayer and Nelson (2020). Unlike the unigram and bigram models, which compute probabilities based on local dependencies, this model allows long distance restrictions such as vowel or consonant harmony to be effectively modeled.
+                </ol>
+                See the <a href="{% url 'about' %}">About</a> page for a detailed description of how these models differ and how to interpret the scores.
+            </li>
+        </ol>
+        The UCI Phonotactic Calculator was developed by <a href="http://connormayer.com">Connor Mayer</a> (UCI), Arya Kondur (UCI), and <a href="https://linguistics.ucla.edu/person/megha-sundara/">Megha Sundara</a> (UCLA). Please direct all inquiries to Connor Mayer (<a href="mailto:cjmayer@uci.edu">cjmayer@uci.edu</a>).
+        <!-- <object data = "/media/descriptions/home.txt" width = "100%" height = "250"></object> -->
     </div>
+
     <div style="padding:40px;margin:40px;border:1px solid #ccc">
         <h1>Provide Input for Calculations</h1>
-        <h3 style="color:blueviolet">Upload a training file or use a default file</h3>
+        <h3 style="color:blueviolet">Upload a training file or select a default file</h3>
         <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form.as_p }}

--- a/webcalc/templates/home.html
+++ b/webcalc/templates/home.html
@@ -10,7 +10,7 @@
         <p>The general use case for this tool is as follows:</p>
         <ol>
             <li>
-                Choose a <i>training file</i>. You can either upload your own or choose one of the default training files (see the <a href="{% url 'about' %}">About</a> page for details on how these should be formatted and the <a href="{% url 'about' %}">Datasets</a> page for a description of the default files). This file is intended to represent the input over which phonotactic generalizations are formed, and will typically be something like a dictionary (a large list of word types). The models used to calculate the phonotactic acceptability metrics will be fit to this data.
+                Choose a <i>training file</i>. You can either upload your own or choose one of the default training files (see the <a href="{% url 'about' %}">About</a> page for details on how these should be formatted and the <a href="{% url 'media' %}">Datasets</a> page for a description of the default files). This file is intended to represent the input over which phonotactic generalizations are formed, and will typically be something like a dictionary (a large list of word types). The models used to calculate the phonotactic acceptability metrics will be fit to this data.
             </li>
             <li>
                 Upload a <i>test file</i>. The trained models will assign scores for each metric to the words in this file. This file may duplicate data in the training file (if you are interested in the scores assigned to existing words) or not (if you are interested in the predictions the various models make about how speakers generalize to new forms).
@@ -19,7 +19,7 @@
                 Choose which <i>model</i> to use. Currently the calculator supports two suites of models.
                 <ol>
                     <li>
-                        <b>Unigram/Bigram scores</b>: this computes a suite of metrics that are based on unigram/bigram frequencies (that is, the frequencies of individual sounds and the frequencies of adjacent pairs of sounds). This includes type- and token-weighted variants of the positional unigram/bigram method from Jusczyk et al. (1994) and Vitevich and Luce (2004), as well as type- and token-weighted variants of standard unigram/bigram probabilities.
+                        <b>Unigram/Bigram scores</b>: this computes a suite of metrics that are based on unigram/bigram frequencies (that is, the frequencies of individual sounds and the frequencies of adjacent pairs of sounds). This includes type- and token-weighted variants of the positional unigram/bigram method from Jusczyk et al. (1994) and Vitevitch and Luce (2004), as well as type- and token-weighted variants of standard unigram/bigram probabilities.
                     </li>
                     <li>
                         <b>RNN Model</b>: this computes an acceptability metric based on the recurrent neural network phonotactic model from Mayer and Nelson (2020). Unlike the unigram and bigram models, which compute probabilities based on local dependencies, this model allows long distance restrictions such as vowel or consonant harmony to be effectively modeled.

--- a/webcalc/templates/home.html
+++ b/webcalc/templates/home.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <div style="padding:40px;margin:40px;border:1px solid #ccc">
-        <center><h3> Welcome to the UCI Phonotactic Calculator! </h3></center>
+        <h3> Welcome to the UCI Phonotactic Calculator! </h3>
 
         <p>This is a research tool that allows users to calculate a variety of <i>phonotactic acceptability metrics</i>. These metrics are intended to capture how probable/acceptable a word is based on the sounds it contains and the order in which those sounds are sequenced. This is sometimes referred to as <i>phonotactic probability</i>, though we prefer the term <i>acceptability</i> because not all of the metrics employed here can be interpreted as probabilities. For example, a nonce word like [stik] 'steek' might have a relatively high phonotactic acceptability score in English even though it is not a real word, because there are many words that begin with [st], end with [ik], and so on. In Spanish, however, this word would have a low acceptability score because there are no Spanish words that begin with the sequence [st]. A sensitivity to the phonotactic constraints of one's language(s) is an important component of linguistic competence, and the various metrics computed by this tool instantiate different models of how this sensitivity is operationalized.</p>
 

--- a/webcalc_project/settings.py
+++ b/webcalc_project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'latexify',
 ]
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
@@ -52,6 +53,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 ROOT_URLCONF = 'webcalc_project.urls'
 


### PR DESCRIPTION
I added the text for the home and about pages.

One crucial change here is that I've added the `latexify` app to the site to allow me to use LaTeX notation in the templates. You'll need to have this installed on your machine/the production server for this to work. You can install it by running `pip install django-latexify`.

Let me know if you have any comments, otherwise I'll merge this in the next day or two.
